### PR TITLE
ci(dependabot): add cooldown default delay

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
 - package-ecosystem: github-actions
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7
 - package-ecosystem: gomod
-  directory: "/"
+  directory: /
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
Adds a 7-day default Dependabot cooldown so CIF deployment has time to complete before dependency update PRs are opened.

This helps avoid getting ahead with versions before they are fully available through deployment.